### PR TITLE
fix(.editorconfig):  make C files save w/o BOM

### DIFF
--- a/LvglPlatform/.editorconfig
+++ b/LvglPlatform/.editorconfig
@@ -9,9 +9,6 @@
 ## MAINTAINER: MouriNaruto (Kenji.Mouri@outlook.com)
 ##
 
-[*]
-charset = utf-8-bom
-
 [*.{c,c++,cc,cpp,cxx,h,h++,hh,hpp,hxx,ixx,cppm,ipp,odl,idl,inl,ipp,tlh,tli}]
 charset = utf-8
 


### PR DESCRIPTION
Since my development workstation is on a Windows platform, when I make modifications/fixes to LVGL library code, I often like to do it in this project first because it offers a great place to test the results.

I found that when I did that and then copied the changes to the LVGL project fork I have, they were coming with BOMs in the files, and the LVGL repository maintainers are trying to keep the BOMs out of the source files because they cause problems in some places.  File format preferred is [UTF-8] instead of [UTF-8 with BOM].

I offer this as help, since most of the C source files under these projects is from the LVGL repository.

Resolves #89