### PR TITLE
Update README Add chapter on applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,39 @@ removed in the submodules then the visual studio project will likely need
 adjusting. See the commit log for examples of submodule updates and associated
 visual studio file changes to guide you.
 
+## Application
+
+The lvgl source code that Visual Studio depends on is located in the 
+LvglPlatform folder (LvglPlatform/lvgl). If your actual project directory 
+already contains the lvgl source code, to avoid wasting storage space redundantly, 
+you can have Visual Studio share the lvgl source code with the actual project, 
+and you can directly delete the lvgl source code in the LvglPlatform folder. 
+After deletion, you need to redirect 
+
+Visual Studio to depend on the lvgl directory in the actual project.
+By examining Visual Studio project files, it can be seen that Visual Studio 
+manages source code locations through .vcxproj and .vcxproj.filters.
+Taking LvglWindowsSimulator as an example, the files that need to be 
+
+modified are as follows (if not modified correctly, compilation will fail):
+
+- LvglWindowsSimulator/LvglWindowsSimulator.vcxproj, storing project configurations
+  and specifying dependent header files.
+
+- LvglWindowsSimulator/LvglWindowsSimulator.vcxproj.filters,
+  specifying source files to compile in the project, which will
+  appear as virtual files/folders in Visual Studio.
+
+- LvglWindowsSimulator/freetype.props, configuring the location
+- of freetype source files, which Visual Studio projects depend on.
+
+Note: Since the executables compiled by Visual Studio and the actual project 
+target different platforms, the lvgl configuration needs to be different. 
+Therefore, lv_conf.h files must be written for each platform, and the 
+differently configured lv_conf.h files should be placed in the directories for 
+the corresponding platforms (sharing the same lv_conf.h file across platforms 
+will cause errors during compilation in Visual Studio or the actual project).
+
 ## Documents
 
 - [ARM32 Support Removed Notice](Documents/Arm32SupportRemovedNotice.md)


### PR DESCRIPTION
When actually using lv_port_pc_visual_studio, developers can move the lvgl source library to another location according to their preferences or project requirements.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an “Application” chapter to the README explaining how to point the Visual Studio simulator to an existing lvgl source and avoid duplicate copies. It lists the project files to update and clarifies per‑platform lv_conf.h requirements.

- **Migration**
  - lvgl is at LvglPlatform/lvgl by default; you can delete it and reference your project’s lvgl.
  - Update LvglWindowsSimulator.vcxproj and LvglWindowsSimulator.vcxproj.filters to new paths.
  - Update LvglWindowsSimulator/freetype.props for freetype source location.
  - Use separate lv_conf.h per platform; do not share one config.

<sup>Written for commit 9797fe02f0e5d4a821d6198d2d59f4852124cc60. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

