### PR TITLE
Bump GitHub action workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,17 +16,17 @@ jobs:
     env:
       POWERSHELL_TELEMETRY_OPTOUT: 1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
       with:
         submodules: 'recursive'
-    - uses: microsoft/setup-msbuild@v1
+    - uses: microsoft/setup-msbuild@v2
     - name: Clear local NuGet cache (workaround for failed restores on windows-latest)
       run: dotnet nuget locals all --clear
     - name: Build
       run: msbuild /m BuildAllTargets.proj
     - name: Prepare artifacts
       run: rm Output\* -vb -Recurse -Force -Include *.exp, *.idb, *.ilk, *.iobj, *.ipdb, *.lastbuildstate, *.lib, *.obj, *.res, *.tlog
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: LVGL_CI_Build
         path: Output


### PR DESCRIPTION
This PR bumpa GitHub action workflows in `CI.yml`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped action versions in CI.yml to improve reliability and security. Build steps and artifacts remain unchanged.

- **Dependencies**
  - actions/checkout: v2 → v6
  - microsoft/setup-msbuild: v1 → v2
  - actions/upload-artifact: v4 → v6

<sup>Written for commit a6d3c466ff90763a23811f7c9014221ccdd4a42a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

